### PR TITLE
CI build fails on Open JDK6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
             <version>2.1</version>

--- a/src/main/java/com/jcabi/aether/Aether.java
+++ b/src/main/java/com/jcabi/aether/Aether.java
@@ -95,6 +95,7 @@ import org.sonatype.aether.util.repository.DefaultProxySelector;
  *  using jcabi-http, provide a maven configuration file with proxy settings
  *  and verify the expected HTTP requests have been sent to the mocked server.
  * @todo #69:30min Fix NullPointerExceptions in CL build for Open JDK6.
+ * @todo #69:30min Fix UnsupportedClassVersionError in CL build for Open JDK6.
  */
 @ToString
 @EqualsAndHashCode(of = { "remotes", "lrepo" })

--- a/src/main/java/com/jcabi/aether/Aether.java
+++ b/src/main/java/com/jcabi/aether/Aether.java
@@ -33,9 +33,7 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.Logger;
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -43,6 +41,7 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.maven.settings.Mirror;
@@ -413,13 +412,14 @@ public final class Aether {
     private Settings invokers(final SettingsBuilder builder,
         final SettingsBuildingResult result) {
         Settings main = result.getEffectiveSettings();
-        final Path path = Paths.get(
-            System.getProperty("user.dir"), "..", "interpolated-settings.xml"
-        );
-        if (Files.exists(path)) {
+        final File[] files = new File(System.getProperty("user.dir"))
+            .getParentFile().listFiles(
+                (FileFilter) new NameFileFilter("interpolated-settings.xml")
+            );
+        if (files.length == 1) {
             final DefaultSettingsBuildingRequest irequest =
                 new DefaultSettingsBuildingRequest();
-            irequest.setUserSettingsFile(path.toAbsolutePath().toFile());
+            irequest.setUserSettingsFile(files[0]);
             try {
                 final Settings isettings = builder.build(irequest)
                     .getEffectiveSettings();

--- a/src/main/java/com/jcabi/aether/Aether.java
+++ b/src/main/java/com/jcabi/aether/Aether.java
@@ -415,7 +415,7 @@ public final class Aether {
         final File[] files = new File(System.getProperty("user.dir"))
             .getParentFile().listFiles(
                 (FileFilter) new NameFileFilter("interpolated-settings.xml")
-            );
+        );
         if (files.length == 1) {
             final DefaultSettingsBuildingRequest irequest =
                 new DefaultSettingsBuildingRequest();

--- a/src/main/java/com/jcabi/aether/Aether.java
+++ b/src/main/java/com/jcabi/aether/Aether.java
@@ -94,6 +94,7 @@ import org.sonatype.aether.util.repository.DefaultProxySelector;
  *  from maven settings.xml file that will mock an HTTP server
  *  using jcabi-http, provide a maven configuration file with proxy settings
  *  and verify the expected HTTP requests have been sent to the mocked server.
+ * @todo #69:30min Fix NullPointerExceptions in CL build for Open JDK6.
  */
 @ToString
 @EqualsAndHashCode(of = { "remotes", "lrepo" })


### PR DESCRIPTION
Fixed compilation for jdk6, removed java.nio.Path usage.
Solving https://github.com/jcabi/jcabi-aether/issues/69