### PR TITLE
Changed @NotNull to Validate.notNull() in Aether.jara

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.kuali.maven.wagons</groupId>

--- a/src/main/java/com/jcabi/aether/Aether.java
+++ b/src/main/java/com/jcabi/aether/Aether.java
@@ -38,10 +38,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.lang3.Validate;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.maven.settings.Mirror;
@@ -121,7 +121,7 @@ public final class Aether {
      * @param prj The Maven project
      * @param repo Local repository location (directory path)
      */
-    public Aether(@NotNull final MavenProject prj, @NotNull final File repo) {
+    public Aether(final MavenProject prj, final File repo) {
         this(prj.getRemoteProjectRepositories(), repo);
     }
 
@@ -133,8 +133,10 @@ public final class Aether {
      * @since 0.8
      */
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    public Aether(@NotNull final Collection<RemoteRepository> repos,
-        @NotNull final File repo) {
+    public Aether(final Collection<RemoteRepository> repos,
+        final File repo) {
+        Validate.notNull(repos, "repos cannot be null");
+        Validate.notNull(repo, "repo cannot be null");
         final Collection<Repository> rlist = new LinkedList<Repository>();
         for (final RemoteRepository remote : this.prepos(this.mrepos(repos))) {
             rlist.add(new Repository(remote));
@@ -150,8 +152,10 @@ public final class Aether {
      * @return The list of dependencies
      * @throws DependencyResolutionException If can't fetch it
      */
-    public List<Artifact> resolve(@NotNull final Artifact root,
-        @NotNull final String scope) throws DependencyResolutionException {
+    public List<Artifact> resolve(final Artifact root,
+        final String scope) throws DependencyResolutionException {
+        Validate.notNull(root, "root parameter cannot be null");
+        Validate.notNull(scope, "scope parameter cannot be null");
         final DependencyFilter filter =
             DependencyFilterUtils.classpathFilter(scope);
         if (filter == null) {
@@ -170,9 +174,12 @@ public final class Aether {
      * @return The list of dependencies
      * @throws DependencyResolutionException If can't fetch it
      */
-    public List<Artifact> resolve(@NotNull final Artifact root,
-        @NotNull final String scope, @NotNull final DependencyFilter filter)
+    public List<Artifact> resolve(final Artifact root,
+        final String scope, final DependencyFilter filter)
         throws DependencyResolutionException {
+        Validate.notNull(root, "root cannot be null");
+        Validate.notNull(scope, "scope cannot be null");
+        Validate.notNull(filter, "filter cannot be null");
         final Dependency rdep = new Dependency(root, scope);
         final CollectRequest crq = this.request(rdep);
         final List<Artifact> deps = new LinkedList<Artifact>();

--- a/src/main/java/com/jcabi/aether/Aether.java
+++ b/src/main/java/com/jcabi/aether/Aether.java
@@ -41,7 +41,6 @@ import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.io.filefilter.NameFileFilter;
-import org.apache.commons.lang3.Validate;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.maven.settings.Mirror;
@@ -135,8 +134,6 @@ public final class Aether {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public Aether(final Collection<RemoteRepository> repos,
         final File repo) {
-        Validate.notNull(repos, "repos cannot be null");
-        Validate.notNull(repo, "repo cannot be null");
         final Collection<Repository> rlist = new LinkedList<Repository>();
         for (final RemoteRepository remote : this.prepos(this.mrepos(repos))) {
             rlist.add(new Repository(remote));
@@ -154,8 +151,6 @@ public final class Aether {
      */
     public List<Artifact> resolve(final Artifact root,
         final String scope) throws DependencyResolutionException {
-        Validate.notNull(root, "root parameter cannot be null");
-        Validate.notNull(scope, "scope parameter cannot be null");
         final DependencyFilter filter =
             DependencyFilterUtils.classpathFilter(scope);
         if (filter == null) {
@@ -177,9 +172,6 @@ public final class Aether {
     public List<Artifact> resolve(final Artifact root,
         final String scope, final DependencyFilter filter)
         throws DependencyResolutionException {
-        Validate.notNull(root, "root cannot be null");
-        Validate.notNull(scope, "scope cannot be null");
-        Validate.notNull(filter, "filter cannot be null");
         final Dependency rdep = new Dependency(root, scope);
         final CollectRequest crq = this.request(rdep);
         final List<Artifact> deps = new LinkedList<Artifact>();

--- a/src/main/java/com/jcabi/aether/Classpath.java
+++ b/src/main/java/com/jcabi/aether/Classpath.java
@@ -40,7 +40,6 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -107,8 +106,8 @@ public final class Classpath extends AbstractSet<File> {
      * @param repo Local repository location (directory path)
      * @param scp The scope to use, e.g. "runtime" or "compile"
      */
-    public Classpath(@NotNull final MavenProject prj,
-        @NotNull final File repo, @NotNull final String scp) {
+    public Classpath(final MavenProject prj, final File repo,
+        final String scp) {
         this(prj, repo, Arrays.asList(scp));
     }
 
@@ -118,8 +117,8 @@ public final class Classpath extends AbstractSet<File> {
      * @param repo Local repository location (directory path)
      * @param scps All scopes to include
      */
-    public Classpath(@NotNull final MavenProject prj,
-        @NotNull final File repo, @NotNull final Collection<String> scps) {
+    public Classpath(final MavenProject prj,
+        final File repo, final Collection<String> scps) {
         super();
         this.project = prj;
         this.aether = new Aether(prj, repo);

--- a/src/main/java/com/jcabi/aether/MavenClasspath.java
+++ b/src/main/java/com/jcabi/aether/MavenClasspath.java
@@ -41,7 +41,6 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -115,9 +114,8 @@ public final class MavenClasspath extends AbstractSet<File> {
      * @param sess Maven session.
      * @param scp The scope to use, e.g. "runtime" or "compile"
      */
-    public MavenClasspath(@NotNull final DependencyGraphBuilder bldr,
-        @NotNull final MavenSession sess,
-        @NotNull final String scp) {
+    public MavenClasspath(final DependencyGraphBuilder bldr,
+        final MavenSession sess, final String scp) {
         this(bldr, sess, Arrays.asList(scp));
     }
 
@@ -127,9 +125,8 @@ public final class MavenClasspath extends AbstractSet<File> {
      * @param sess Maven session.
      * @param scps All scopes to include
      */
-    public MavenClasspath(@NotNull final DependencyGraphBuilder bldr,
-        @NotNull final MavenSession sess,
-        @NotNull final Collection<String> scps) {
+    public MavenClasspath(final DependencyGraphBuilder bldr,
+        final MavenSession sess, final Collection<String> scps) {
         super();
         this.builder = bldr;
         this.session = sess;

--- a/src/main/java/com/jcabi/aether/MavenRootArtifact.java
+++ b/src/main/java/com/jcabi/aether/MavenRootArtifact.java
@@ -33,7 +33,6 @@ import com.jcabi.aspects.Cacheable;
 import com.jcabi.log.Logger;
 import java.util.Collection;
 import java.util.List;
-import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Exclusion;
@@ -51,19 +50,16 @@ final class MavenRootArtifact {
     /**
      * The artifact.
      */
-    @NotNull
     private final transient Artifact art;
 
     /**
      * Exclusions.
      */
-    @NotNull
     private final transient Collection<Exclusion> exclusions;
 
     /**
      * This artifact child artifacts.
      */
-    @NotNull
     private final transient Collection<Artifact> chldrn;
 
     /**
@@ -72,9 +68,8 @@ final class MavenRootArtifact {
      * @param excl Exclusions
      * @param chld Child artifacts
      */
-    protected MavenRootArtifact(@NotNull final Artifact artifact,
-        @NotNull final List<Exclusion> excl,
-        @NotNull final Collection<Artifact> chld) {
+    protected MavenRootArtifact(final Artifact artifact,
+        final List<Exclusion> excl, final Collection<Artifact> chld) {
         this.art = artifact;
         this.exclusions = excl;
         this.chldrn = chld;
@@ -127,7 +122,7 @@ final class MavenRootArtifact {
      * @param artifact The artifact to check
      * @return TRUE if it should be excluded
      */
-    public boolean excluded(@NotNull final Artifact artifact) {
+    public boolean excluded(final Artifact artifact) {
         boolean excluded = false;
         for (final Exclusion exclusion : this.exclusions) {
             if (exclusion.getArtifactId().equals(artifact.getArtifactId())

--- a/src/main/java/com/jcabi/aether/RootArtifact.java
+++ b/src/main/java/com/jcabi/aether/RootArtifact.java
@@ -33,7 +33,6 @@ import com.jcabi.aspects.Cacheable;
 import com.jcabi.log.Logger;
 import java.util.Collection;
 import java.util.List;
-import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import org.apache.maven.model.Exclusion;
 import org.sonatype.aether.artifact.Artifact;
@@ -55,19 +54,16 @@ final class RootArtifact {
     /**
      * The aether for finding children.
      */
-    @NotNull
     private final transient Aether aether;
 
     /**
      * The artifact.
      */
-    @NotNull
     private final transient Artifact art;
 
     /**
      * Exclusions.
      */
-    @NotNull
     private final transient Collection<Exclusion> exclusions;
 
     /**
@@ -76,9 +72,8 @@ final class RootArtifact {
      * @param artifact The artifact
      * @param excl Exclusions
      */
-    protected RootArtifact(@NotNull final Aether aeth,
-        @NotNull final Artifact artifact,
-        @NotNull final Collection<Exclusion> excl) {
+    protected RootArtifact(final Aether aeth,
+        final Artifact artifact, final Collection<Exclusion> excl) {
         this.aether = aeth;
         this.art = artifact;
         this.exclusions = excl;
@@ -138,7 +133,7 @@ final class RootArtifact {
      * @param artifact The artifact to check
      * @return TRUE if it should be excluded
      */
-    public boolean excluded(@NotNull final Artifact artifact) {
+    public boolean excluded(final Artifact artifact) {
         boolean excluded = false;
         for (final Exclusion exclusion : this.exclusions) {
             if (exclusion.getArtifactId().equals(artifact.getArtifactId())

--- a/src/test/java/com/jcabi/aether/AetherTest.java
+++ b/src/test/java/com/jcabi/aether/AetherTest.java
@@ -166,45 +166,6 @@ public final class AetherTest {
     }
 
     /**
-     * Aether can reject NULL Maven project.
-     * @throws Exception If there is some problem inside
-     */
-    @Test(expected = java.lang.NullPointerException.class)
-    public void rejectsNullMavenProject() throws Exception {
-        final MavenProject project = null;
-        new Aether(project, this.temp.newFolder());
-    }
-
-    /**
-     * Aether can reject NULL repository path.
-     * @throws Exception If there is some problem inside
-     */
-    @Test(expected = java.lang.NullPointerException.class)
-    public void rejectsNullRepoPath() throws Exception {
-        new Aether(this.project(), null);
-    }
-
-    /**
-     * Aether can reject NULL artifact.
-     * @throws Exception If there is some problem inside
-     */
-    @Test(expected = java.lang.NullPointerException.class)
-    public void rejectsNullArtifact() throws Exception {
-        new Aether(this.project(), this.temp.newFolder())
-            .resolve(null, JavaScopes.RUNTIME);
-    }
-
-    /**
-     * Aether can reject NULL scope.
-     * @throws Exception If there is some problem inside
-     */
-    @Test(expected = java.lang.NullPointerException.class)
-    public void rejectsNullScope() throws Exception {
-        new Aether(this.project(), this.temp.newFolder())
-            .resolve(new DefaultArtifact("junit:junit:4.10"), null);
-    }
-
-    /**
      * Aether can throw on non-found artifact.
      * @throws Exception If there is some problem inside
      */

--- a/src/test/java/com/jcabi/aether/AetherTest.java
+++ b/src/test/java/com/jcabi/aether/AetherTest.java
@@ -169,7 +169,7 @@ public final class AetherTest {
      * Aether can reject NULL Maven project.
      * @throws Exception If there is some problem inside
      */
-    @Test(expected = javax.validation.ConstraintViolationException.class)
+    @Test(expected = java.lang.NullPointerException.class)
     public void rejectsNullMavenProject() throws Exception {
         final MavenProject project = null;
         new Aether(project, this.temp.newFolder());
@@ -179,7 +179,7 @@ public final class AetherTest {
      * Aether can reject NULL repository path.
      * @throws Exception If there is some problem inside
      */
-    @Test(expected = javax.validation.ConstraintViolationException.class)
+    @Test(expected = java.lang.NullPointerException.class)
     public void rejectsNullRepoPath() throws Exception {
         new Aether(this.project(), null);
     }
@@ -188,7 +188,7 @@ public final class AetherTest {
      * Aether can reject NULL artifact.
      * @throws Exception If there is some problem inside
      */
-    @Test(expected = javax.validation.ConstraintViolationException.class)
+    @Test(expected = java.lang.NullPointerException.class)
     public void rejectsNullArtifact() throws Exception {
         new Aether(this.project(), this.temp.newFolder())
             .resolve(null, JavaScopes.RUNTIME);
@@ -198,7 +198,7 @@ public final class AetherTest {
      * Aether can reject NULL scope.
      * @throws Exception If there is some problem inside
      */
-    @Test(expected = javax.validation.ConstraintViolationException.class)
+    @Test(expected = java.lang.NullPointerException.class)
     public void rejectsNullScope() throws Exception {
         new Aether(this.project(), this.temp.newFolder())
             .resolve(new DefaultArtifact("junit:junit:4.10"), null);


### PR DESCRIPTION
This PR is for issue #78 . Build under openjdk6 (and oraclejdk6) fails when ``javax.validation.constraints.@NotNull`` is used for validation, so I used ``org.apache.commons.lang3.Validate.notNull()`` instead.