### PR TITLE
Variable ctor arguments for Classpath and MavenClasspath + unit tests

### DIFF
--- a/src/main/java/com/jcabi/aether/Classpath.java
+++ b/src/main/java/com/jcabi/aether/Classpath.java
@@ -30,6 +30,7 @@
 package com.jcabi.aether;
 
 import com.jcabi.aspects.Loggable;
+
 import java.io.File;
 import java.util.AbstractSet;
 import java.util.Arrays;
@@ -40,7 +41,9 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import lombok.EqualsAndHashCode;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Dependency;
@@ -107,7 +110,7 @@ public final class Classpath extends AbstractSet<File> {
      * @param scp The scope to use, e.g. "runtime" or "compile"
      */
     public Classpath(final MavenProject prj, final File repo,
-        final String scp) {
+        final String... scp) {
         this(prj, repo, Arrays.asList(scp));
     }
 

--- a/src/main/java/com/jcabi/aether/Classpath.java
+++ b/src/main/java/com/jcabi/aether/Classpath.java
@@ -107,11 +107,11 @@ public final class Classpath extends AbstractSet<File> {
      * Public ctor.
      * @param prj The Maven project
      * @param repo Local repository location (directory path)
-     * @param scp The scope to use, e.g. "runtime" or "compile"
+     * @param scps The scopes to use, e.g. "runtime", "compile" etc
      */
     public Classpath(final MavenProject prj, final File repo,
-        final String... scp) {
-        this(prj, repo, Arrays.asList(scp));
+        final String... scps) {
+        this(prj, repo, Arrays.asList(scps));
     }
 
     /**

--- a/src/main/java/com/jcabi/aether/Classpath.java
+++ b/src/main/java/com/jcabi/aether/Classpath.java
@@ -30,7 +30,6 @@
 package com.jcabi.aether;
 
 import com.jcabi.aspects.Loggable;
-
 import java.io.File;
 import java.util.AbstractSet;
 import java.util.Arrays;
@@ -41,9 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import lombok.EqualsAndHashCode;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Dependency;

--- a/src/main/java/com/jcabi/aether/MavenClasspath.java
+++ b/src/main/java/com/jcabi/aether/MavenClasspath.java
@@ -112,11 +112,11 @@ public final class MavenClasspath extends AbstractSet<File> {
      * Public ctor.
      * @param bldr Dependency graph builder.
      * @param sess Maven session.
-     * @param scp The scope to use, e.g. "runtime" or "compile"
+     * @param scps The scopes to use, e.g. "runtime", "compile" etc
      */
     public MavenClasspath(final DependencyGraphBuilder bldr,
-        final MavenSession sess, final String... scp) {
-        this(bldr, sess, Arrays.asList(scp));
+        final MavenSession sess, final String... scps) {
+        this(bldr, sess, Arrays.asList(scps));
     }
 
     /**

--- a/src/main/java/com/jcabi/aether/MavenClasspath.java
+++ b/src/main/java/com/jcabi/aether/MavenClasspath.java
@@ -115,7 +115,7 @@ public final class MavenClasspath extends AbstractSet<File> {
      * @param scp The scope to use, e.g. "runtime" or "compile"
      */
     public MavenClasspath(final DependencyGraphBuilder bldr,
-        final MavenSession sess, final String scp) {
+        final MavenSession sess, final String... scp) {
         this(bldr, sess, Arrays.asList(scp));
     }
 

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -92,6 +92,35 @@ public final class ClasspathTest {
             )
         );
     }
+/**
+     * Classpath can build a classpath with more scopes
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void buildsClasspathWithMoreScopes() throws Exception {
+        MatcherAssert.assertThat(
+            new Classpath(
+                this.project(
+                    this.dependency(
+                        ClasspathTest.GROUP, ClasspathTest.GROUP, "4.10"
+                    )
+                ), this.temp.newFolder(), JavaScopes.TEST, JavaScopes.COMPILE
+            ),
+            Matchers.<File>hasItems(
+                Matchers.hasToString(
+                    Matchers.endsWith(
+                        String.format(
+                            // @checkstyle MultipleStringLiterals (2 lines)
+                            "%sas%<sdirectory",
+                            System.getProperty("file.separator")
+                        )
+                    )
+                ),
+                Matchers.hasToString(Matchers.endsWith("junit-4.10.jar")),
+                Matchers.hasToString(Matchers.endsWith("hamcrest-core-1.1.jar"))
+            )
+        );
+    }
 
     /**
      * Classpath should return artifact with highest version number.

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -57,6 +57,16 @@ public final class ClasspathTest {
     private static final String GROUP = "junit";
 
     /**
+     * Sdirectory format.
+     */
+    private static final String SDIR = "%sas%<sdirectory";
+
+    /**
+     * File separator.
+     */
+    private static final String FILE_SEP = "file.separator";
+
+    /**
      * Temp dir.
      * @checkstyle VisibilityModifier (3 lines)
      */
@@ -81,9 +91,8 @@ public final class ClasspathTest {
                 Matchers.hasToString(
                     Matchers.endsWith(
                         String.format(
-                            // @checkstyle MultipleStringLiterals (2 lines)
-                            "%sas%<sdirectory",
-                            System.getProperty("file.separator")
+                            ClasspathTest.SDIR,
+                            System.getProperty(ClasspathTest.FILE_SEP)
                         )
                     )
                 ),
@@ -111,9 +120,8 @@ public final class ClasspathTest {
                 Matchers.hasToString(
                     Matchers.endsWith(
                         String.format(
-                            // @checkstyle MultipleStringLiterals (2 lines)
-                            "%sas%<sdirectory",
-                            System.getProperty("file.separator")
+                            ClasspathTest.SDIR,
+                            System.getProperty(ClasspathTest.FILE_SEP)
                         )
                     )
                 ),

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -155,7 +155,7 @@ public final class ClasspathTest {
                     Matchers.hasToString(
                         Matchers.endsWith(
                             String.format(
-                                ClasspathTest.SDIR
+                                ClasspathTest.SDIR,
                                 System.getProperty(ClasspathTest.FILE_SEP)
                             )
                         )

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -108,14 +108,12 @@ public final class ClasspathTest {
      */
     @Test
     public void buildsClasspathWithMoreScopes() throws Exception {
-        final String vrs = "1.5.2";
+        final String artf = "jcabi-ssh";
+    	final String vrs = "1.5.2";
         MatcherAssert.assertThat(
             new Classpath(
-                this.project(
-                    this.dependency(
-                        "com.jcabi", "jcabi-ssh", vrs
-                    )
-                ), this.temp.newFolder(), JavaScopes.TEST, JavaScopes.COMPILE
+                this.project(this.dependency("com.jcabi", artf, vrs)),
+                this.temp.newFolder(), JavaScopes.TEST, JavaScopes.COMPILE
             ),
             Matchers.<File>hasItems(
                 Matchers.hasToString(
@@ -127,7 +125,7 @@ public final class ClasspathTest {
                     )
                 ),
                 Matchers.hasToString(
-                    Matchers.endsWith(String.format("jcabi-ssh-%s.jar", vrs))
+                    Matchers.endsWith(String.format("%s-%s.jar", artf, vrs))
                 )
             )
         );

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -109,7 +109,7 @@ public final class ClasspathTest {
     @Test
     public void buildsClasspathWithMoreScopes() throws Exception {
         final String artf = "jcabi-ssh";
-    	final String vrs = "1.5.2";
+        final String vrs = "1.5.2";
         MatcherAssert.assertThat(
             new Classpath(
                 this.project(this.dependency("com.jcabi", artf, vrs)),

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -112,7 +112,7 @@ public final class ClasspathTest {
             new Classpath(
                 this.project(
                     this.dependency(
-                        ClasspathTest.GROUP, ClasspathTest.GROUP, "4.12"
+                        "com.jcabi", "jcabi-ssh", "1.5.2"
                     )
                 ), this.temp.newFolder(), JavaScopes.TEST, JavaScopes.COMPILE
             ),
@@ -125,7 +125,7 @@ public final class ClasspathTest {
                         )
                     )
                 ),
-                Matchers.hasToString(Matchers.endsWith("junit-4.12.jar"))
+                Matchers.hasToString(Matchers.endsWith(".jar"))
             )
         );
     }
@@ -155,9 +155,8 @@ public final class ClasspathTest {
                     Matchers.hasToString(
                         Matchers.endsWith(
                             String.format(
-                                // @checkstyle MultipleStringLiterals (2 lines)
-                                "%sas%<sdirectory",
-                                System.getProperty("file.separator")
+                                ClasspathTest.SDIR
+                                System.getProperty(ClasspathTest.FILE_SEP)
                             )
                         )
                     ),

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -92,8 +92,9 @@ public final class ClasspathTest {
             )
         );
     }
-/**
-     * Classpath can build a classpath with more scopes
+
+    /**
+     * Classpath can build a classpath with more scopes.
      * @throws Exception If there is some problem inside
      */
     @Test
@@ -102,7 +103,7 @@ public final class ClasspathTest {
             new Classpath(
                 this.project(
                     this.dependency(
-                        ClasspathTest.GROUP, ClasspathTest.GROUP, "4.10"
+                        ClasspathTest.GROUP, ClasspathTest.GROUP, "4.12"
                     )
                 ), this.temp.newFolder(), JavaScopes.TEST, JavaScopes.COMPILE
             ),
@@ -116,8 +117,7 @@ public final class ClasspathTest {
                         )
                     )
                 ),
-                Matchers.hasToString(Matchers.endsWith("junit-4.10.jar")),
-                Matchers.hasToString(Matchers.endsWith("hamcrest-core-1.1.jar"))
+                Matchers.hasToString(Matchers.endsWith("junit-4.12.jar"))
             )
         );
     }

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -108,7 +108,7 @@ public final class ClasspathTest {
      */
     @Test
     public void buildsClasspathWithMoreScopes() throws Exception {
-    	final String vrs = "1.5.2";
+        final String vrs = "1.5.2";
         MatcherAssert.assertThat(
             new Classpath(
                 this.project(

--- a/src/test/java/com/jcabi/aether/ClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/ClasspathTest.java
@@ -108,11 +108,12 @@ public final class ClasspathTest {
      */
     @Test
     public void buildsClasspathWithMoreScopes() throws Exception {
+    	final String vrs = "1.5.2";
         MatcherAssert.assertThat(
             new Classpath(
                 this.project(
                     this.dependency(
-                        "com.jcabi", "jcabi-ssh", "1.5.2"
+                        "com.jcabi", "jcabi-ssh", vrs
                     )
                 ), this.temp.newFolder(), JavaScopes.TEST, JavaScopes.COMPILE
             ),
@@ -125,7 +126,9 @@ public final class ClasspathTest {
                         )
                     )
                 ),
-                Matchers.hasToString(Matchers.endsWith(".jar"))
+                Matchers.hasToString(
+                    Matchers.endsWith(String.format("jcabi-ssh-%s.jar", vrs))
+                )
             )
         );
     }

--- a/src/test/java/com/jcabi/aether/MavenClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/MavenClasspathTest.java
@@ -116,10 +116,7 @@ public final class MavenClasspathTest {
         Mockito.when(session.getCurrentProject()).thenReturn(project);
         MatcherAssert.assertThat(
             new MavenClasspath(
-                builder,
-                session,
-                JavaScopes.TEST,
-                JavaScopes.COMPILE
+                builder, session, JavaScopes.TEST, JavaScopes.COMPILE
             ),
             Matchers.<File>hasItems(
                 Matchers.hasToString(
@@ -240,7 +237,7 @@ public final class MavenClasspathTest {
      * @param group Dependency group
      * @param artifact Dependency artifact ID
      * @param version Dependency Version
-     * @return Created dependency.
+     * @return Created dependency
      */
     private Dependency dependency(final String group, final String artifact,
         final String version) {

--- a/src/test/java/com/jcabi/aether/MavenClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/MavenClasspathTest.java
@@ -55,16 +55,16 @@ import org.sonatype.aether.util.artifact.JavaScopes;
 @SuppressWarnings("unchecked")
 public final class MavenClasspathTest {
 
-	/**
+    /**
      * Sdirectory format.
      */
-	private static final String SDIR = "%sas%<sdirectory";
+    private static final String SDIR = "%sas%<sdirectory";
 
-	/**
-	 * File separator.
-	 */
-	private static final String FILE_SEP = "file.separator";
-	
+    /**
+     * File separator.
+     */
+    private static final String FILE_SEP = "file.separator";
+
     /**
      * Temp dir.
      * @checkstyle VisibilityModifier (3 lines)
@@ -78,7 +78,7 @@ public final class MavenClasspathTest {
      */
     @Test
     public void buildsClasspath() throws Exception {
-    	final String group = "junit";
+        final String group = "junit";
         final String jar = "junit-4.10.jar";
         final DependencyGraphBuilder builder = this.builder(jar);
         final MavenSession session = Mockito.mock(MavenSession.class);

--- a/src/test/java/com/jcabi/aether/MavenClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/MavenClasspathTest.java
@@ -113,7 +113,9 @@ public final class MavenClasspathTest {
         final String artf = "jcabi-xml";
         final String vrs = "0.17.2";
         final String jar = "%s-%s.jar";
-        final DependencyGraphBuilder builder = this.builder(String.format(jar, artf, vrs));
+        final DependencyGraphBuilder builder = this.builder(
+            String.format(jar, artf, vrs)
+        );
         final MavenSession session = Mockito.mock(MavenSession.class);
         final MavenProject project = this.project(
             this.dependency("com.jcabi", artf, vrs)
@@ -132,7 +134,11 @@ public final class MavenClasspathTest {
                         )
                     )
                 ),
-                Matchers.hasToString(Matchers.endsWith(String.format(jar, artf, vrs)))
+                Matchers.hasToString(
+                    Matchers.endsWith(
+                        String.format(jar, artf, vrs)
+                    )
+                )
             )
         );
     }

--- a/src/test/java/com/jcabi/aether/MavenClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/MavenClasspathTest.java
@@ -55,11 +55,16 @@ import org.sonatype.aether.util.artifact.JavaScopes;
 @SuppressWarnings("unchecked")
 public final class MavenClasspathTest {
 
-    /**
-     * Group of test artifact.
+	/**
+     * Sdirectory format.
      */
-    private static final String GROUP = "junit";
+	private static final String SDIR = "%sas%<sdirectory";
 
+	/**
+	 * File separator.
+	 */
+	private static final String FILE_SEP = "file.separator";
+	
     /**
      * Temp dir.
      * @checkstyle VisibilityModifier (3 lines)
@@ -73,12 +78,13 @@ public final class MavenClasspathTest {
      */
     @Test
     public void buildsClasspath() throws Exception {
+    	final String group = "junit";
         final String jar = "junit-4.10.jar";
         final DependencyGraphBuilder builder = this.builder(jar);
         final MavenSession session = Mockito.mock(MavenSession.class);
         final MavenProject project = this.project(
             this.dependency(
-                MavenClasspathTest.GROUP, MavenClasspathTest.GROUP, "4.10"
+                group, group, "4.10"
             )
         );
         Mockito.when(session.getCurrentProject()).thenReturn(project);
@@ -88,9 +94,8 @@ public final class MavenClasspathTest {
                 Matchers.hasToString(
                     Matchers.endsWith(
                         String.format(
-                            // @checkstyle MultipleStringLiterals (2 lines)
-                            "%sas%<sdirectory",
-                            System.getProperty("file.separator")
+                            MavenClasspathTest.SDIR,
+                            System.getProperty(MavenClasspathTest.FILE_SEP)
                         )
                     )
                 ),
@@ -105,12 +110,12 @@ public final class MavenClasspathTest {
      */
     @Test
     public void buildsClasspathWithMoreScopes() throws Exception {
-        final String jar = "junit-4.11.jar";
+        final String jar = "jcabi-xml-0.17.2.jar";
         final DependencyGraphBuilder builder = this.builder(jar);
         final MavenSession session = Mockito.mock(MavenSession.class);
         final MavenProject project = this.project(
             this.dependency(
-                MavenClasspathTest.GROUP, MavenClasspathTest.GROUP, "4.11"
+                "com.jcabi", "jcabi-xml", "0.17.2"
             )
         );
         Mockito.when(session.getCurrentProject()).thenReturn(project);
@@ -122,9 +127,8 @@ public final class MavenClasspathTest {
                 Matchers.hasToString(
                     Matchers.endsWith(
                         String.format(
-                            // @checkstyle MultipleStringLiterals (2 lines)
-                            "%sas%<sdirectory",
-                            System.getProperty("file.separator")
+                            MavenClasspathTest.SDIR,
+                            System.getProperty(MavenClasspathTest.FILE_SEP)
                         )
                     )
                 ),

--- a/src/test/java/com/jcabi/aether/MavenClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/MavenClasspathTest.java
@@ -62,7 +62,7 @@ public final class MavenClasspathTest {
     public final transient TemporaryFolder temp = new TemporaryFolder();
 
     /**
-     * Classpath can build a classpath.
+     * MavenClasspath can build a classpath.
      * @throws Exception If there is some problem inside
      */
     @Test
@@ -94,6 +94,44 @@ public final class MavenClasspathTest {
         );
     }
 
+    /**
+     * MavenClasspath can build a classpath when there are more scopes.
+     * @throws Exception If there is some problem inside
+     */
+    @Test
+    public void buildsClasspathWithMoreScopes() throws Exception {
+        final Dependency dep = new Dependency();
+        final String group = "junit";
+        dep.setGroupId(group);
+        dep.setArtifactId(group);
+        dep.setVersion("4.10");
+        dep.setScope("test");
+        final String jar = "junit-4.10.jar";
+        final DependencyGraphBuilder builder = this.builder(jar);
+        final MavenSession session = Mockito.mock(MavenSession.class);
+        final MavenProject project = this.project(dep);
+        Mockito.when(session.getCurrentProject()).thenReturn(project);
+        MatcherAssert.assertThat(
+            new MavenClasspath(
+                builder,
+                session,
+                MavenClasspath.TEST_SCOPE,
+                MavenClasspath.COMPILE_SCOPE
+            ),
+            Matchers.<File>hasItems(
+                Matchers.hasToString(
+                    Matchers.endsWith(
+                        String.format(
+                            "%sas%<sdirectory",
+                            System.getProperty("file.separator")
+                        )
+                    )
+                ),
+                Matchers.hasToString(Matchers.endsWith(jar))
+            )
+        );
+    }
+    
     /**
      * Classpath can return a string when a dependency is broken.
      * @throws Exception If there is some problem inside

--- a/src/test/java/com/jcabi/aether/MavenClasspathTest.java
+++ b/src/test/java/com/jcabi/aether/MavenClasspathTest.java
@@ -110,13 +110,13 @@ public final class MavenClasspathTest {
      */
     @Test
     public void buildsClasspathWithMoreScopes() throws Exception {
-        final String jar = "jcabi-xml-0.17.2.jar";
-        final DependencyGraphBuilder builder = this.builder(jar);
+        final String artf = "jcabi-xml";
+        final String vrs = "0.17.2";
+        final String jar = "%s-%s.jar";
+        final DependencyGraphBuilder builder = this.builder(String.format(jar, artf, vrs));
         final MavenSession session = Mockito.mock(MavenSession.class);
         final MavenProject project = this.project(
-            this.dependency(
-                "com.jcabi", "jcabi-xml", "0.17.2"
-            )
+            this.dependency("com.jcabi", artf, vrs)
         );
         Mockito.when(session.getCurrentProject()).thenReturn(project);
         MatcherAssert.assertThat(
@@ -132,7 +132,7 @@ public final class MavenClasspathTest {
                         )
                     )
                 ),
-                Matchers.hasToString(Matchers.endsWith(jar))
+                Matchers.hasToString(Matchers.endsWith(String.format(jar, artf, vrs)))
             )
         );
     }


### PR DESCRIPTION
This is for ticket #88 
Added variable parameter ``String... scps`` instead of single param ``String scp`` for ``Classpath`` and ``MavenClasspath`` constructors. 